### PR TITLE
【Task28】Create Forgot Password page②

### DIFF
--- a/question28/forgotPassword.html
+++ b/question28/forgotPassword.html
@@ -16,7 +16,7 @@
                     <ul>
                         <li>
                             <label for="mail">メールアドレス</label>
-                            <input type="email" id="mail" name="user_email" class="js-email" required />
+                            <input type="email" id="mail" name="email" class="js-email" required />
                             <span class="error"></span>
                         </li>
                     </ul>

--- a/question28/js/forgotpassword.js
+++ b/question28/js/forgotpassword.js
@@ -21,7 +21,7 @@ mailInputArea.addEventListener('blur', (e) => {
 
 const checkData = (emailAddressValue) => {
   const registeredUserData = JSON.parse(localStorage.getItem('userData'));
-  return ((emailAddressValue === registeredUserData.user_email));
+  return emailAddressValue === registeredUserData.user_email;
 }
 
 const userDataVerification = () => {

--- a/question28/js/forgotpassword.js
+++ b/question28/js/forgotpassword.js
@@ -54,9 +54,8 @@ const init = async () => {
   }
 
   const tokenForPasswordReset = verificationResult.token;
-  const passwordResetPageUrl = "./register/password.html";
   localStorage.setItem('tokenForforgotPassword', tokenForPasswordReset);
-  window.location.href = `${passwordResetPageUrl}?token=${tokenForPasswordReset}`;
+  window.location.href = `./register/password.html?token=${tokenForPasswordReset}`;
 }
 
 submitButton.addEventListener('click',init);

--- a/question28/js/forgotpassword.js
+++ b/question28/js/forgotpassword.js
@@ -6,7 +6,7 @@ const submitButton = document.getElementById('js-submit-button');
 const mailInputArea = document.querySelector(".js-email");
 
 
-const checkAllValidity = () => {
+const isValidAllInputsValue = () => {
   return document.getElementsByTagName("input").length === document.getElementsByClassName("valid").length;
 }
 
@@ -16,7 +16,7 @@ const toggleDisabledOfSubmitButton = (isValid) => {
 
 mailInputArea.addEventListener('blur', (e) => {
   validateInputValue(e);
-  toggleDisabledOfSubmitButton(checkAllValidity());
+  toggleDisabledOfSubmitButton(isValidAllInputsValue());
 });
 
 const checkData = (emailAddressValue) => {

--- a/question28/js/forgotpassword.js
+++ b/question28/js/forgotpassword.js
@@ -21,7 +21,7 @@ mailInputArea.addEventListener('blur', (e) => {
 
 const checkData = (emailAddressValue) => {
   const registeredUserData = JSON.parse(localStorage.getItem('userData'));
-  return emailAddressValue === registeredUserData.user_email;
+  return emailAddressValue === registeredUserData.email;
 }
 
 const userDataVerification = () => {

--- a/question28/js/login.js
+++ b/question28/js/login.js
@@ -31,9 +31,9 @@ passwordInputArea.addEventListener('blur', (e) => {
 });
 
 
-const checkData = ({ name_mail, user_password }) => {
+const checkData = ({ name_mail, password }) => {
   const registeredUserData = JSON.parse(localStorage.getItem('userData'));
-  return ((name_mail === registeredUserData.user_email || name_mail === registeredUserData.user_name) && (user_password === registeredUserData.user_password));
+  return ((name_mail === registeredUserData.email || name_mail === registeredUserData.name) && (password === registeredUserData.password));
 }
 
 

--- a/question28/js/modules/validations.js
+++ b/question28/js/modules/validations.js
@@ -15,12 +15,12 @@ const validationInfo = {
     errorMessage: '※メールアドレスの形式になっていません。' 
   },
   password: {
-    validation : (value) => /(?=.*[a-zA-Z])(?=.*[0-9])[a-zA-z0-9]{8,}/.test(value),
+    validation : (value) => /^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])[a-zA-Z0-9]{8,}$/.test(value),
     errorMessage: '※8文字以上の大小の英数字を交ぜたものにしてください。'  
   },
   confirmPassword: {
-    validation : (value) => /(?=.*[a-zA-Z])(?=.*[0-9])[a-zA-z0-9]{8,}/.test(value),
-    errorMessage: '※8文字以上の大小の英数字を交ぜたものにしてください。' 
+    validation : (value) => /^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])[a-zA-Z0-9]{8,}$/.test(value),
+    errorMessage: '※8文字以上の大小の英数字を交ぜたものにしてください。'  
   }
 }
 

--- a/question28/js/modules/validations.js
+++ b/question28/js/modules/validations.js
@@ -17,6 +17,10 @@ const validationInfo = {
   password: {
     validation : (value) => /(?=.*[a-zA-Z])(?=.*[0-9])[a-zA-z0-9]{8,}/.test(value),
     errorMessage: '※8文字以上の大小の英数字を交ぜたものにしてください。'  
+  },
+  confirmPassword: {
+    validation : (value) => /(?=.*[a-zA-Z])(?=.*[0-9])[a-zA-z0-9]{8,}/.test(value),
+    errorMessage: '※8文字以上の大小の英数字を交ぜたものにしてください。' 
   }
 }
 

--- a/question28/js/modules/validations.js
+++ b/question28/js/modules/validations.js
@@ -9,16 +9,12 @@ const validationInfo = {
     validation: (value) => value.length > validationInfo.name.minNameLength && value.length < validationInfo.name.maxNameLength,
     errorMessage: '※ユーザー名は1文字以上15文字以下にしてください。',
   },
-  mail: {
+  email: {
     //Reference: https://1-notes.com/javascript-determine-if-it-is-an-email-address/ 
     validation : (value) => /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/.test(value),
     errorMessage: '※メールアドレスの形式になっていません。' 
   },
   password: {
-    validation : (value) => /^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])[a-zA-Z0-9]{8,}$/.test(value),
-    errorMessage: '※8文字以上の大小の英数字を交ぜたものにしてください。'  
-  },
-  confirmPassword: {
     validation : (value) => /^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])[a-zA-Z0-9]{8,}$/.test(value),
     errorMessage: '※8文字以上の大小の英数字を交ぜたものにしてください。'  
   }
@@ -42,12 +38,12 @@ export const invalidEvent = (targetForm) => {
     return; 
   }
 
-  targetForm.nextElementSibling.textContent = validationInfo[targetForm.id].errorMessage;
+  targetForm.nextElementSibling.textContent = validationInfo[targetForm.name].errorMessage;
 };
 
 export const validateInputValue = (e) => {
   const targetForm = e.target;
   const value = targetForm.value.trim();
-  const result = validationInfo[targetForm.id].validation(value);
+  const result = validationInfo[targetForm.name].validation(value);
   setValidationEvents(result,targetForm);
 } 

--- a/question28/js/password.js
+++ b/question28/js/password.js
@@ -5,7 +5,7 @@ const passwordInputArea = document.querySelector(".js-password");
 const confirmPasswordInputArea = document.querySelector(".js-confirm-password");
 
 
-const checkAllValidity = () => {
+const isValidAllInputsValue = () => {
   return document.getElementsByTagName("input").length === document.getElementsByClassName("valid").length && passwordInputArea.value === confirmPasswordInputArea.value;
 }
 
@@ -23,7 +23,7 @@ for (const input of [passwordInputArea, confirmPasswordInputArea]) {
       showErrorMessageInputValuesMismatch(); 
     }
     
-    toggleDisabledOfSubmitButton(checkAllValidity());
+    toggleDisabledOfSubmitButton(isValidAllInputsValue());
   });
 }
 

--- a/question28/js/password.js
+++ b/question28/js/password.js
@@ -13,15 +13,17 @@ const toggleDisabledOfSubmitButton = (isValid) => {
   submitButton.disabled = !isValid;
 }
 
-const showErrorMessageInputValuesMismatch = () => confirmPasswordInputArea.nextElementSibling.textContent = passwordInputArea.value !== confirmPasswordInputArea.value ? "入力されたパスワードが一致しませんでした" : "";
-
 for (const input of [passwordInputArea, confirmPasswordInputArea]) {
   input.addEventListener("blur", (e) => {
     validateInputValue(e);
-    
-    if (passwordInputArea.value && confirmPasswordInputArea.value) {
-      showErrorMessageInputValuesMismatch(); 
+
+    if (isValidAllInputsValue()) {
+      confirmPasswordInputArea.nextElementSibling.textContent = ""; 
     }
+    
+    if (passwordInputArea.value && confirmPasswordInputArea.value && passwordInputArea.value !== confirmPasswordInputArea.value) {
+      confirmPasswordInputArea.nextElementSibling.textContent = "入力された値が一致してません";
+    } 
     
     toggleDisabledOfSubmitButton(isValidAllInputsValue());
   });

--- a/question28/js/password.js
+++ b/question28/js/password.js
@@ -1,0 +1,35 @@
+import { validateInputValue } from "./modules/validations";
+
+const submitButton = document.getElementById('js-submit-button');
+const passwordInputArea = document.querySelector(".js-password");
+const confirmPasswordInputArea = document.querySelector(".js-confirm-password");
+
+
+const checkAllValidity = () => {
+  return document.getElementsByTagName("input").length === document.getElementsByClassName("valid").length && passwordInputArea.value === confirmPasswordInputArea.value;
+}
+
+const toggleDisabledOfSubmitButton = (isValid) => {
+  submitButton.disabled = !isValid;
+}
+
+const showErrorMessageInputValuesMismatch = () => confirmPasswordInputArea.nextElementSibling.textContent = passwordInputArea.value !== confirmPasswordInputArea.value ? "入力されたパスワードが一致しませんでした" : "";
+
+for (const input of [passwordInputArea, confirmPasswordInputArea]) {
+  input.addEventListener("blur", (e) => {
+    validateInputValue(e);
+    
+    if (passwordInputArea.value && confirmPasswordInputArea.value) {
+      showErrorMessageInputValuesMismatch(); 
+    }
+    
+    toggleDisabledOfSubmitButton(checkAllValidity());
+  });
+}
+
+
+const init = () => {
+  console.log('未実装です');
+}
+
+submitButton.addEventListener('click',init);

--- a/question28/js/register.js
+++ b/question28/js/register.js
@@ -66,7 +66,7 @@ submitButton.addEventListener('click',() => {
   const registeredUserData = JSON.parse(localStorage.getItem('userData'));
   const inputUserData = Object.fromEntries([...new FormData(form)]);
 
-  if (registeredUserData && registeredUserData.user_email === inputUserData.user_email) {
+  if (registeredUserData && registeredUserData.email === inputUserData.email) {
     mailInputArea.nextElementSibling.textContent = "すでに登録されているメールアドレスです";
     submitButton.disabled = true;
     return;

--- a/question28/js/register.js
+++ b/question28/js/register.js
@@ -35,7 +35,7 @@ const checkWhenIntersect = ([entry]) => {
     checkbox.checked = true;
     checkbox.disabled = false;
     checkbox.classList.add("valid");
-    toggleDisabledOfSubmitButton(checkAllValidity() && checkbox.checked);
+    toggleDisabledOfSubmitButton(isValidAllInputsValue() && checkbox.checked);
   };
 };
 
@@ -43,7 +43,7 @@ const observer = new IntersectionObserver(checkWhenIntersect, options);
 observer.observe(modalContainer.lastElementChild);
 
 
-const checkAllValidity = () => {
+const isValidAllInputsValue = () => {
   return document.getElementsByTagName("input").length === document.getElementsByClassName("valid").length;
 }
 
@@ -54,12 +54,12 @@ const toggleDisabledOfSubmitButton = (isValid) => {
 for (const input of [nameInputArea, mailInputArea, passwordInputArea]) {
   input.addEventListener("blur", (e) => {
     validateInputValue(e);
-    toggleDisabledOfSubmitButton(checkAllValidity() && checkbox.checked);
+    toggleDisabledOfSubmitButton(isValidAllInputsValue() && checkbox.checked);
   });
 }
 
 checkbox.addEventListener("change", () => {
-  toggleDisabledOfSubmitButton(checkAllValidity() && checkbox.checked);
+  toggleDisabledOfSubmitButton(isValidAllInputsValue() && checkbox.checked);
 });
 
 submitButton.addEventListener('click',() => {

--- a/question28/js/register.js
+++ b/question28/js/register.js
@@ -63,7 +63,15 @@ checkbox.addEventListener("change", () => {
 });
 
 submitButton.addEventListener('click',() => {
-  const userData = Object.fromEntries([...new FormData(form)]);
-  localStorage.setItem('userData', JSON.stringify(userData)); 
+  const registeredUserData = JSON.parse(localStorage.getItem('userData'));
+  const inputUserData = Object.fromEntries([...new FormData(form)]);
+
+  if (registeredUserData && registeredUserData.user_email === inputUserData.user_email) {
+    mailInputArea.nextElementSibling.textContent = "すでに登録されているメールアドレスです";
+    submitButton.disabled = true;
+    return;
+  }
+
+  localStorage.setItem('userData', JSON.stringify(inputUserData)); 
   window.location.href = './register-done.html';
 })

--- a/question28/login.html
+++ b/question28/login.html
@@ -22,7 +22,7 @@
                             </li>
                             <li>
                                 <label for="password">パスワード</label>
-                                <input type="password" autocomplete="current-password" id="password" name="password" class="js-password" required />
+                                <input type="password" autocomplete="current-password" id="current-password" name="password" class="js-password" required />
                                 <span class="error"></span>
                             </li>
                         </ul>

--- a/question28/login.html
+++ b/question28/login.html
@@ -22,7 +22,7 @@
                             </li>
                             <li>
                                 <label for="password">パスワード</label>
-                                <input type="password" autocomplete="current-password" id="password" name="user_password" class="js-password" required />
+                                <input type="password" autocomplete="current-password" id="password" name="password" class="js-password" required />
                                 <span class="error"></span>
                             </li>
                         </ul>

--- a/question28/login.html
+++ b/question28/login.html
@@ -22,7 +22,7 @@
                             </li>
                             <li>
                                 <label for="password">パスワード</label>
-                                <input type="password" id="password" name="user_password" class="js-password" required />
+                                <input type="password" autocomplete="current-password" id="password" name="user_password" class="js-password" required />
                                 <span class="error"></span>
                             </li>
                         </ul>

--- a/question28/register.html
+++ b/question28/register.html
@@ -26,7 +26,7 @@
                         </li>
                         <li>
                             <label for="password">パスワード</label>
-                            <input type="password" id="password" name="user_password" class="js-password" required>
+                            <input type="password" autocomplete="new-password" id="password" name="user_password" class="js-password" required>
                             <span class="error"></span>
                         </li>
                     </ul>

--- a/question28/register.html
+++ b/question28/register.html
@@ -26,7 +26,7 @@
                         </li>
                         <li>
                             <label for="password">パスワード</label>
-                            <input type="password" autocomplete="new-password" id="password" name="password" class="js-password" required>
+                            <input type="password" autocomplete="new-password" id="new-password" name="password" class="js-password" required>
                             <span class="error"></span>
                         </li>
                     </ul>

--- a/question28/register.html
+++ b/question28/register.html
@@ -16,17 +16,17 @@
                     <ul>
                         <li>
                             <label for="name">ユーザー名</label>
-                            <input type="text" id="name" name="user_name" class="js-name" required data-maxlength="16"/>
+                            <input type="text" id="name" name="name" class="js-name" required data-maxlength="16"/>
                             <span class="error"></span>
                         </li>
                         <li>
                             <label for="mail">メールアドレス</label>
-                            <input type="email" id="mail" name="user_email" class="js-email" required>
+                            <input type="email" id="mail" name="email" class="js-email" required>
                             <span class="error"></span>
                         </li>
                         <li>
                             <label for="password">パスワード</label>
-                            <input type="password" autocomplete="new-password" id="password" name="user_password" class="js-password" required>
+                            <input type="password" autocomplete="new-password" id="password" name="password" class="js-password" required>
                             <span class="error"></span>
                         </li>
                     </ul>

--- a/question28/register/password.html
+++ b/question28/register/password.html
@@ -16,12 +16,12 @@
                     <ul>
                         <li>
                             <label for="password">新規パスワード入力</label>
-                            <input type="password" autocomplete="new-password" id="password" name="password" required class="input js-password"/>
+                            <input type="password" autocomplete="new-password" id="new-password" name="password" required class="input js-password"/>
                             <span class="error"></span>
                         </li>
                         <li>
                             <label for="confirmPassword">確認のためのパスワード入力</label>
-                            <input type="password" autocomplete="new-password" id="confirmPassword" name="password" required class="input js-confirm-password"/>
+                            <input type="password" autocomplete="new-password" id="confirm-password" name="password" required class="input js-confirm-password"/>
                             <span class="error"></span>
                         </li>
                     </ul>

--- a/question28/register/password.html
+++ b/question28/register/password.html
@@ -16,12 +16,12 @@
                     <ul>
                         <li>
                             <label for="password">新規パスワード入力</label>
-                            <input type="password" autocomplete="new-password" id="password" name="new_password" required class="input js-password"/>
+                            <input type="password" autocomplete="new-password" id="password" name="password" required class="input js-password"/>
                             <span class="error"></span>
                         </li>
                         <li>
                             <label for="confirmPassword">確認のためのパスワード入力</label>
-                            <input type="password" autocomplete="new-password" id="confirmPassword" name="confirm_password" required class="input js-confirm-password"/>
+                            <input type="password" autocomplete="new-password" id="confirmPassword" name="password" required class="input js-confirm-password"/>
                             <span class="error"></span>
                         </li>
                     </ul>

--- a/question28/register/password.html
+++ b/question28/register/password.html
@@ -16,12 +16,12 @@
                     <ul>
                         <li>
                             <label for="password">新規パスワード入力</label>
-                            <input type="password" id="password" name="new_password" required class="input js-password"/>
+                            <input type="password" autocomplete="new-password" id="password" name="new_password" required class="input js-password"/>
                             <span class="error"></span>
                         </li>
                         <li>
                             <label for="confirmPassword">確認のためのパスワード入力</label>
-                            <input type="password" id="confirmPassword" name="confirm_password" required class="input js-confirm-password"/>
+                            <input type="password" autocomplete="new-password" id="confirmPassword" name="confirm_password" required class="input js-confirm-password"/>
                             <span class="error"></span>
                         </li>
                     </ul>

--- a/question28/register/password.html
+++ b/question28/register/password.html
@@ -4,6 +4,7 @@
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+        <script type="module" src="../js/password.js"></script>
         <link href="../css/style.css" rel="stylesheet" />
         <title>TerraceTechフロントエンドエンジニア養成所</title>
     </head>
@@ -14,13 +15,13 @@
                 <div>
                     <ul>
                         <li>
-                            <label for="new_password">新規パスワード入力</label>
-                            <input type="text" id="new_password" name="new_password" required class="input"/>
+                            <label for="password">新規パスワード入力</label>
+                            <input type="password" id="password" name="new_password" required class="input js-password"/>
                             <span class="error"></span>
                         </li>
                         <li>
-                            <label for="password">確認のためのパスワード入力</label>
-                            <input type="password" id="password" name="user_password" required class="input"/>
+                            <label for="confirmPassword">確認のためのパスワード入力</label>
+                            <input type="password" id="confirmPassword" name="confirm_password" required class="input js-confirm-password"/>
                             <span class="error"></span>
                         </li>
                     </ul>


### PR DESCRIPTION
# [Task28]
パスワードを忘れた方へ画面作成
https://github.com/kenmori/handsonFrontend/blob/master/work/markup/1.md#28

## [codesandbox](https://codesandbox.io/s/github/csakyo/homework/tree/feature/task28-2/question28?file=/js/password.js) / Latest commit:https://github.com/csakyo/homework/pull/43/commits/76fdaed82425a2677a611f7c2694dbdc00799890

## 課題28仕様
パスワード忘れた方へ(forgetpassword.html)のページを作ってください

## 前回実装済
この課題から会員登録された内容はlocalstorage内に保有され ログイン時は固定値ではなく localstorage内の値とチェックされます。 イメージしたいのはローカルストレージはここではサーバー内のテーブルとして使っています。 なので現実的ではそのような実装はないですが、ここの課題はそれで実装したいです 

## 今回実装点
①会員登録画面(register.js)
会員登録画面でsubmitした時、localStorage内の値とチェックしてメールアドレスが既に登録されていた場合はエラーを出します。

②パスワードをお忘れの方へ(forgotpassword.js)
上記で作ったメールアドレス兼ユーザー名を入力するところがあります
メールアドレスのinput値がバリデーションを通れば送信ボタンが押せます
もしメールアドレスが登録がされていない場合は「見つかりませんでした」というエラーメッセージを出してください
この課題の実装では forgetpassword.htmlでsubmitしたらトークンを発行して(仮にこの説明では482r22fafahとします)、ローカルストレージに保存。 そのあと register/password.htmlへ飛ばしてください
その際のリンクはregister/password.html?token=482r22fafah みたいなurlにして(このリンクが本来メール本文にあるリンクのイメージです)

③パスワード再設定ページ(password.js)
「新規パスワード入力」 「確認のためのパスワード入力」 があり、バリデーションも効きます

### 確認してほしい点
【動作確認してほしい箇所】
①会員登録画面(register.html)
一度会員登録した後、ローカルストレージに既にあるメールアドレスで再登録しようとするとエラーが出る

↓パスワードをお忘れの方へページへ遷移してもらい

②パスワードをお忘れの方へページ(forgotpassword.html)
・入力値が間違っている場合エラーが出る
・メールアドレスのバリデーションが通ればsubmitボタンが押せて、password.htmlへ飛べる

↓forgotpassword.htmlから遷移すると

③パスワード再設定ページ
・パラメータ(発行されたトークン(tokenForforgotPassword))付きのURLになっている
・新規PWと確認用PWの入力値を入れればsubmitボタン押せる
・新規PWと確認用PWの入力値が相違ある場合にエラーが出る（submitボタン押せない）

### 前回の課題から変更したファイル
・register.js
・forgotpassword.js
・/module/validation.js

### 前回の課題から追加したファイル
・password.js

## 未実装箇所
フロントはurlパラメータのtokenがすぐ前で発行した482r22fafahかどうかを確認します。 (ローカルストレージがサーバー側の役割をしているイメージ)
もしtokenが間違っていたら notautherize.html 権限がありませんページに飛ばしてください
urlパラメータが正しい場合にregister/password.htmlを表示します
表示は下記の通りで

inputの値が同じでバリデーションが通ればパスワードを再発行と新たなトークンを発行して ローカルストレージに埋め込みor以前のそれを破棄、変更してください

パスワード再設定完了ページ
register/passworddone.html?token=tagaerega <-新しいトークン で飛ばします
完了ページでは urlパラメータからトークンと直近で作られたトークンがローカルストレージのそれと合っていたら
「パスワード再設定が完了しました」 「ログインページへ」
を表示し
間違っていたりトークンがなかったり直叩きでurlが間違っていたら 権限なしページに飛ばしてください
その後、新たに作ったパスワードでログインができるようにします

## [Comment for this Task]
Please see below for the changes and additions that have been made.