### PR TITLE
【Task28】Create Forgot Password page④

### DIFF
--- a/question28/css/common.css
+++ b/question28/css/common.css
@@ -1,0 +1,39 @@
+body,
+div,
+dl,
+dt,
+dd,
+ul,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+pre,
+code,
+form,
+fieldset,
+legend,
+input,
+textarea,
+p,
+blockquote,
+th,
+td {
+  margin: 0;
+  padding: 0;
+}
+* {
+    box-sizing: border-box;
+}
+table {
+    border-collapse: collapse;
+    border-spacing: 0;
+}
+img {
+    max-width: 100%;
+}
+li {
+    list-style: none;
+}

--- a/question28/css/form.css
+++ b/question28/css/form.css
@@ -82,4 +82,20 @@ input.valid {
     cursor: pointer;
     font-size: 15px;
 }
-
+.done {
+    max-width: 800px;
+    padding: 30px;
+    border-radius: 10px;
+    background: #fff;
+    margin: 30px auto;
+    text-align: center;
+    width: 100%;
+    box-shadow: 3px 6px 10px #999;
+}
+.done_txt {
+    color: #353030;
+    margin-bottom: 2rem;
+}
+.done_txt p:first-child{
+    font-size: 30px;
+}

--- a/question28/css/form.css
+++ b/question28/css/form.css
@@ -23,6 +23,9 @@ input.invalid {
 input.valid {
     border: 2px solid #94c35d;
 }
+input.invalid_mismatch {
+    border: 2px solid red;
+}
 .error {
     color: red;
     font-size: 12px;

--- a/question28/css/form.css
+++ b/question28/css/form.css
@@ -1,4 +1,4 @@
-.form-title {
+.form_title {
     text-align: center;
     color: #000;
     font-size: 30px;
@@ -6,7 +6,7 @@
     font-family: 'Didot', sans-serif;
     letter-spacing: 2px;
 }
-.form-list {
+.form_list {
     position: relative;
     margin-bottom: 20px;
     height: 75px;
@@ -67,7 +67,7 @@ input.valid {
     vertical-align: middle;
     margin-right: 8px;
 }
-.password-toggle-button {
+.password_toggle_button {
     color: #6a6f71;
     font-weight: bold;
     background: #f1f4f6;

--- a/question28/css/form.css
+++ b/question28/css/form.css
@@ -1,0 +1,85 @@
+.form-title {
+    text-align: center;
+    color: #000;
+    font-size: 30px;
+    margin-bottom: 30px;
+    font-family: 'Didot', sans-serif;
+    letter-spacing: 2px;
+}
+.form-list {
+    position: relative;
+    margin-bottom: 20px;
+    height: 75px;
+}
+input {
+    width: 100%;
+    border: 1px solid #ccc;
+    height: 45px;
+    border-radius: 3px;
+}
+input.invalid {
+    border: 2px solid red;
+}
+input.valid {
+    border: 2px solid #94c35d;
+}
+.error {
+    color: red;
+    font-size: 12px;
+}
+.submit_button {
+    width: 100%;
+    background: #000;
+    font-size: 1rem;
+    line-height: 1.2;
+    font-weight: 300;
+    height: 60px;
+    color: #fff;
+    border-radius: 30px;
+    cursor: pointer;
+    pointer-events: auto;
+}
+.submit_button:disabled {
+    background: #ccc;
+    cursor: not-allowed;
+    pointer-events: none;
+}
+.close_button {
+    width: 50px;
+    height: 50px;
+    background: #000;
+    font-size: 2.5rem;
+    line-height: 1.2;
+    font-weight: 300;
+    color: #fff;
+    border-radius: 30px;
+    position: absolute;
+    top: 0;
+    right: 0;
+    cursor: pointer;
+}
+.checkbox {
+    margin: 20px 0;
+}
+.checkbox input {
+    height: 25px;
+    width: 25px;
+    vertical-align: middle;
+    margin-right: 8px;
+}
+.password-toggle-button {
+    color: #6a6f71;
+    font-weight: bold;
+    background: #f1f4f6;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    padding: 5px 10px;
+    letter-spacing: 2px;
+    position: absolute;
+    right: 1%;
+    top: 38%;
+    display: block;
+    cursor: pointer;
+    font-size: 15px;
+}
+

--- a/question28/css/style.css
+++ b/question28/css/style.css
@@ -70,26 +70,6 @@ body {
 .mask.hidden {
     display: none;
 }
-.register-done {
-    max-width: 800px;
-    padding: 30px;
-    border-radius: 10px;
-    background: #fff;
-    margin: 30px auto;
-    text-align: center;
-    width: 100%;
-    box-shadow: 3px 6px 10px #999;
-}
-.register-done p {
-    color: #353030;
-}
-.register-done_txt {
-    color: #353030;
-    margin-bottom: 2rem;
-}
-.register-done_txt p:first-child{
-    font-size: 30px;
-}
 .login .link {
     margin-top: 30px;
 }

--- a/question28/css/style.css
+++ b/question28/css/style.css
@@ -1,39 +1,3 @@
-body,
-div,
-dl,
-dt,
-dd,
-ul,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-pre,
-code,
-form,
-fieldset,
-legend,
-input,
-textarea,
-p,
-blockquote,
-th,
-td {
-  margin: 0;
-  padding: 0;
-}
-* {
-    box-sizing: border-box;
-}
-table {
-    border-collapse: collapse;
-    border-spacing: 0;
-}
-img {
-    max-width: 100%;
-}
 body {
     height: 100vh;
     position: relative;
@@ -59,88 +23,6 @@ body {
     transform: translateY(-50%) translateX(-50%);
     box-shadow: 3px 6px 10px #999;
 }
-h1 {
-    text-align: center;
-    color: #000;
-    font-size: 30px;
-    margin-bottom: 30px;
-    font-family: 'Didot', sans-serif;
-    letter-spacing: 2px;
-}
-h2 {
-    text-align: center;
-    font-size: 28px;
-    margin-bottom: 25px;
-}
-.modal p {
-    font-size: 15px;
-}
-ol ol {
-    list-style: upper-alpha;
-}
-li {
-    margin-bottom: 20px;
-    list-style: none;
-}
-form li {
-    height: 75px;
-}
-.submit_button {
-    width: 100%;
-    background: #000;
-    font-size: 1rem;
-    line-height: 1.2;
-    font-weight: 300;
-    height: 60px;
-    color: #fff;
-    border-radius: 30px;
-    cursor: pointer;
-    pointer-events: auto;
-}
-.submit_button:disabled {
-    background: #ccc;
-    cursor: not-allowed;
-    pointer-events: none;
-}
-.close_button {
-    width: 50px;
-    height: 50px;
-    background: #000;
-    font-size: 2.5rem;
-    line-height: 1.2;
-    font-weight: 300;
-    color: #fff;
-    border-radius: 30px;
-    position: absolute;
-    top: 0;
-    right: 0;
-    cursor: pointer;
-}
-input {
-    width: 100%;
-    border: 1px solid #ccc;
-    height: 45px;
-    border-radius: 3px;
-}
-input.invalid {
-    border: 2px solid red;
-}
-input.valid {
-    border: 2px solid #94c35d;
-}
-.error {
-    color: red;
-    font-size: 12px;
-}
-.checkbox {
-    margin: 20px 0;
-}
-.checkbox input {
-    height: 25px;
-    width: 25px;
-    vertical-align: middle;
-    margin-right: 8px;
-}
 .modal {
     max-width: 500px;
     width: 100%;
@@ -159,8 +41,19 @@ input.valid {
     overflow: scroll;
     padding: 30px;
 }
-.modal_content{
+.modal_title {
+    text-align: center;
+    font-size: 28px;
+    margin-bottom: 25px;
+}
+.modal_content {
     margin-bottom: 20px;
+}
+.modal_text li {
+    list-style: inherit;
+}
+.modal_text ol {
+    list-style: lower-alpha;
 }
 .modal.hidden {
     transform:translate(0,-1300px);
@@ -199,22 +92,4 @@ input.valid {
 }
 .login .link {
     margin-top: 30px;
-}
-.form-list {
-    position: relative;
-}
-.password-toggle-button {
-    color: #6a6f71;
-    font-weight: bold;
-    background: #f1f4f6;
-    border: 1px solid #ccc;
-    border-radius: 8px;
-    padding: 5px 10px;
-    letter-spacing: 2px;
-    position: absolute;
-    right: 1%;
-    top: 38%;
-    display: block;
-    cursor: pointer;
-    font-size: 15px;
 }

--- a/question28/forgotPassword.html
+++ b/question28/forgotPassword.html
@@ -12,11 +12,11 @@
     </head>
     <body>
         <div id="js-wrapper" class="wrapper">
-            <h1 class="form-title">Forgot Password</h1>
+            <h1 class="form_title">Forgot Password</h1>
             <form method="post" id="js-form" novalidate>
                 <div>
                     <ul>
-                        <li class="form-list">
+                        <li class="form_list">
                             <label for="mail">メールアドレス</label>
                             <input type="email" id="mail" name="email" class="js-email" required />
                             <span class="error"></span>

--- a/question28/forgotPassword.html
+++ b/question28/forgotPassword.html
@@ -4,17 +4,19 @@
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta http-equiv="X-UA-Compatible" content="ie=edge" />
-        <link href="./css/style.css" rel="stylesheet" />
+        <link href="../css/style.css" rel="stylesheet" />
+        <link href="../css/common.css" rel="stylesheet" />
+        <link href="../css/form.css" rel="stylesheet" />
         <script type="module" src="./js/forgotpassword.js"></script>
         <title>TerraceTechフロントエンドエンジニア養成所</title>
     </head>
     <body>
         <div id="js-wrapper" class="wrapper">
-            <h1>Forgot Password</h1>
+            <h1 class="form-title">Forgot Password</h1>
             <form method="post" id="js-form" novalidate>
                 <div>
                     <ul>
-                        <li>
+                        <li class="form-list">
                             <label for="mail">メールアドレス</label>
                             <input type="email" id="mail" name="email" class="js-email" required />
                             <span class="error"></span>

--- a/question28/js/forgotpassword.js
+++ b/question28/js/forgotpassword.js
@@ -28,7 +28,7 @@ const userDataVerification = () => {
   const userData = mailInputArea.value;
   return new Promise((resolve,reject) => {
     if (checkData(userData)){
-      resolve({ token: chance.apple_token(), ok: true, code: 200 });
+      resolve({ token: chance.guid(), ok: true, code: 200 });
     } else {
       reject({ ok: false, code: 401 }); 
     }

--- a/question28/js/forgotpassword.js
+++ b/question28/js/forgotpassword.js
@@ -53,9 +53,9 @@ const init = async () => {
     return; 
   }
 
-  const tokenForPasswordReset = verificationResult.token;
-  localStorage.setItem('tokenForforgotPassword', tokenForPasswordReset);
-  window.location.href = `./register/password.html?token=${tokenForPasswordReset}`;
+  const token = verificationResult.token;
+  localStorage.setItem('tokenForPasswordReset', token);
+  window.location.href = `./register/password.html?token=${token}`;
 }
 
 submitButton.addEventListener('click',init);

--- a/question28/js/login.js
+++ b/question28/js/login.js
@@ -44,7 +44,7 @@ const userDataVerification = () => {
   const userData = Object.fromEntries([...new FormData(form)]);
   return new Promise((resolve,reject) => {
     if (checkData(userData)){
-      resolve({ token: chance.apple_token(), ok: true, code: 200 });
+      resolve({ token: chance.guid(), ok: true, code: 200 });
     } else {
       reject({ ok: false, code: 401 }); 
     }

--- a/question28/js/modules/validations.js
+++ b/question28/js/modules/validations.js
@@ -17,6 +17,10 @@ const validationInfo = {
   password: {
     validation : (value) => /^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])[a-zA-Z0-9]{8,}$/.test(value),
     errorMessage: '※8文字以上の大小の英数字を交ぜたものにしてください。'  
+  },
+  confirm_password: {
+    validation: (value) => value,
+    errorMessage: '※入力必須項目です',
   }
 }
 

--- a/question28/js/password-done.js
+++ b/question28/js/password-done.js
@@ -1,4 +1,4 @@
 const url = new URL(window.location.href);
 const params = url.searchParams;
 
-if(params.get('token') !== localStorage.getItem('takenForSetNewPassword')) window.location.href = '../notautherize.html';
+if(params.get('token') !== localStorage.getItem('tokenForNewPassword')) window.location.href = '../notautherize.html';

--- a/question28/js/password-done.js
+++ b/question28/js/password-done.js
@@ -1,0 +1,4 @@
+const url = new URL(window.location.href);
+const params = url.searchParams;
+
+if(params.get('token') !== localStorage.getItem('takenForSetNewPassword')) window.location.href = '../notautherize.html';

--- a/question28/js/password.js
+++ b/question28/js/password.js
@@ -7,7 +7,6 @@ const submitButton = document.getElementById('js-submit-button');
 const passwordInputArea = document.querySelector('[data-input="password"]');
 const confirmPasswordInputArea = document.querySelector('[data-input="confirm-password"]');
 const passwordToggleButtons = document.querySelectorAll('[data-button]');
-// const newPasswordValue = passwordInputArea.value;
 
 const url = new URL(window.location.href);
 const params = url.searchParams;

--- a/question28/js/password.js
+++ b/question28/js/password.js
@@ -25,22 +25,24 @@ const toggleDisabledOfSubmitButton = (isValid) => {
 for (const input of [passwordInputArea, confirmPasswordInputArea]) {
   input.addEventListener("blur", (e) => {
     validateInputValue(e);
-
+    
+    if (confirmPasswordInputArea.value && !(passwordInputArea.value === confirmPasswordInputArea.value)) {
+        confirmPasswordInputArea.nextElementSibling.textContent = "入力された値が一致してません";
+        confirmPasswordInputArea.classList.add("invalid_mismatch");
+      }
+      
     if (isValidAllInputsValue()) {
-      confirmPasswordInputArea.nextElementSibling.textContent = ""; 
+      confirmPasswordInputArea.nextElementSibling.textContent = "";
+      confirmPasswordInputArea.classList.remove("invalid_mismatch");
     }
-    
-    if (passwordInputArea.value && confirmPasswordInputArea.value && passwordInputArea.value !== confirmPasswordInputArea.value) {
-      confirmPasswordInputArea.nextElementSibling.textContent = "入力された値が一致してません";
-    } 
-    
-    toggleDisabledOfSubmitButton(isValidAllInputsValue());
-  });
-}
 
-passwordToggleButtons.forEach((passwordToggleButton) => {
-  passwordToggleButton.addEventListener('click', togglePassword); 
-});
+      toggleDisabledOfSubmitButton(isValidAllInputsValue());
+    });
+  }
+  
+  passwordToggleButtons.forEach((passwordToggleButton) => {
+    passwordToggleButton.addEventListener('click', togglePassword); 
+  });
 
 const setNewPassword = (passwordValue) => {
   const registeredUserData = localStorage.getItem('userData');

--- a/question28/js/password.js
+++ b/question28/js/password.js
@@ -45,8 +45,7 @@ passwordToggleButtons.forEach((passwordToggleButton) => {
 const setNewPassword = () => {
   const registeredUserData = localStorage.getItem('userData');
   if(!registeredUserData) {
-    window.location.href = "../notautherize.html";;
-    return;
+    window.location.href = "../notautherize.html";
   }
   const registeredUserJsonData = JSON.parse(registeredUserData);
   const newPasswordValue = passwordInputArea.value;
@@ -60,7 +59,7 @@ const init = () => {
   const token = chance.guid();
   localStorage.setItem('tokenForNewPassword', token);
   localStorage.removeItem('tokenForPasswordReset');
-  // window.location.href = `./password-done.html?token=${token}`;
+  window.location.href = `./password-done.html?token=${token}`;
 }
 
 submitButton.addEventListener('click',init);

--- a/question28/js/password.js
+++ b/question28/js/password.js
@@ -42,20 +42,20 @@ passwordToggleButtons.forEach((passwordToggleButton) => {
   passwordToggleButton.addEventListener('click', togglePassword); 
 });
 
-const setNewPassword = (newPasswordValue) => {
+const setNewPassword = (passwordValue) => {
   const registeredUserData = localStorage.getItem('userData');
   if(!registeredUserData) {
     window.location.href = "../notautherize.html";
   }
   const registeredUserJsonData = JSON.parse(registeredUserData);
-  registeredUserJsonData.password = newPasswordValue; 
+  registeredUserJsonData.password = passwordValue; 
   const newUserData = JSON.stringify(registeredUserJsonData);
   localStorage.setItem('userData', newUserData);
 }
 
 const init = () => {
-  const newPasswordValue = passwordInputArea.value;
-  setNewPassword(newPasswordValue);
+  const passwordValue = passwordInputArea.value;
+  setNewPassword(passwordValue);
   const token = chance.guid();
   localStorage.setItem('tokenForNewPassword', token);
   localStorage.removeItem('tokenForPasswordReset');

--- a/question28/js/password.js
+++ b/question28/js/password.js
@@ -53,7 +53,7 @@ const setNewPassword = () => {
 
 const init = () => {
   setNewPassword ();
-  const takenForSetNewPassword = chance.apple_token();
+  const takenForSetNewPassword = chance.guid();
   localStorage.setItem('takenForSetNewPassword', takenForSetNewPassword);
   localStorage.removeItem("tokenForforgotPassword");
   window.location.href = `./password-done.html?token=${takenForSetNewPassword}`;

--- a/question28/js/password.js
+++ b/question28/js/password.js
@@ -40,8 +40,18 @@ passwordToggleButtons.forEach((passwordToggleButton) => {
   passwordToggleButton.addEventListener('click', togglePassword); 
 });
 
+const setNewPassword = () => {
+  const newPasswordValue = passwordInputArea.value;
+  const registeredUserData = localStorage.getItem('userData'); 
+  const registeredUserJsonData = JSON.parse(registeredUserData);
+  registeredUserJsonData.password = newPasswordValue; 
+  const newUserData = JSON.stringify(registeredUserJsonData);
+  localStorage.setItem('userData', newUserData);
+}
+
 const init = () => {
-  console.log('未実装です');
+  setNewPassword ();
+  window.location.href = './password-done.html';
 }
 
 submitButton.addEventListener('click',init);

--- a/question28/js/password.js
+++ b/question28/js/password.js
@@ -55,6 +55,7 @@ const init = () => {
   setNewPassword ();
   const takenForSetNewPassword = chance.apple_token();
   localStorage.setItem('takenForSetNewPassword', takenForSetNewPassword);
+  localStorage.removeItem("tokenForforgotPassword");
   window.location.href = `./password-done.html?token=${takenForSetNewPassword}`;
 }
 

--- a/question28/js/password.js
+++ b/question28/js/password.js
@@ -1,5 +1,7 @@
 import { validateInputValue } from "./modules/validations";
 import { togglePassword } from "./modules/togglePassword";
+import { Chance } from "chance";
+const chance = new Chance();
 
 const submitButton = document.getElementById('js-submit-button');
 const passwordInputArea = document.querySelector('[data-input="password"]');
@@ -51,7 +53,9 @@ const setNewPassword = () => {
 
 const init = () => {
   setNewPassword ();
-  window.location.href = './password-done.html';
+  const takenForSetNewPassword = chance.apple_token();
+  localStorage.setItem('takenForSetNewPassword', takenForSetNewPassword);
+  window.location.href = `./password-done.html?token=${takenForSetNewPassword}`;
 }
 
 submitButton.addEventListener('click',init);

--- a/question28/js/password.js
+++ b/question28/js/password.js
@@ -7,6 +7,7 @@ const submitButton = document.getElementById('js-submit-button');
 const passwordInputArea = document.querySelector('[data-input="password"]');
 const confirmPasswordInputArea = document.querySelector('[data-input="confirm-password"]');
 const passwordToggleButtons = document.querySelectorAll('[data-button]');
+// const newPasswordValue = passwordInputArea.value;
 
 const url = new URL(window.location.href);
 const params = url.searchParams;
@@ -42,20 +43,20 @@ passwordToggleButtons.forEach((passwordToggleButton) => {
   passwordToggleButton.addEventListener('click', togglePassword); 
 });
 
-const setNewPassword = () => {
+const setNewPassword = (newPasswordValue) => {
   const registeredUserData = localStorage.getItem('userData');
   if(!registeredUserData) {
     window.location.href = "../notautherize.html";
   }
   const registeredUserJsonData = JSON.parse(registeredUserData);
-  const newPasswordValue = passwordInputArea.value;
   registeredUserJsonData.password = newPasswordValue; 
   const newUserData = JSON.stringify(registeredUserJsonData);
   localStorage.setItem('userData', newUserData);
 }
 
 const init = () => {
-  setNewPassword ();
+  const newPasswordValue = passwordInputArea.value;
+  setNewPassword(newPasswordValue);
   const token = chance.guid();
   localStorage.setItem('tokenForNewPassword', token);
   localStorage.removeItem('tokenForPasswordReset');

--- a/question28/js/password.js
+++ b/question28/js/password.js
@@ -2,8 +2,8 @@ import { validateInputValue } from "./modules/validations";
 import { togglePassword } from "./modules/togglePassword";
 
 const submitButton = document.getElementById('js-submit-button');
-const passwordInputArea = document.querySelector(".js-password");
-const confirmPasswordInputArea = document.querySelector(".js-confirm-password");
+const passwordInputArea = document.querySelector('[data-input="password"]');
+const confirmPasswordInputArea = document.querySelector('[data-input="confirm-password"]');
 const passwordToggleButtons = document.querySelectorAll('[data-button]');
 
 const url = new URL(window.location.href);

--- a/question28/js/password.js
+++ b/question28/js/password.js
@@ -11,7 +11,7 @@ const passwordToggleButtons = document.querySelectorAll('[data-button]');
 const url = new URL(window.location.href);
 const params = url.searchParams;
 
-if(params.get('token') !== localStorage.getItem('tokenForforgotPassword')) window.location.href = ('../notautherize.html');
+if(params.get('token') !== localStorage.getItem('tokenForPasswordReset')) window.location.href = ('../notautherize.html');
 
 
 const isValidAllInputsValue = () => {
@@ -53,10 +53,10 @@ const setNewPassword = () => {
 
 const init = () => {
   setNewPassword ();
-  const takenForSetNewPassword = chance.guid();
-  localStorage.setItem('takenForSetNewPassword', takenForSetNewPassword);
-  localStorage.removeItem("tokenForforgotPassword");
-  window.location.href = `./password-done.html?token=${takenForSetNewPassword}`;
+  const token = chance.guid();
+  localStorage.setItem('tokenForNewPassword', token);
+  localStorage.removeItem('tokenForPasswordReset');
+  window.location.href = `./password-done.html?token=${token}`;
 }
 
 submitButton.addEventListener('click',init);

--- a/question28/js/password.js
+++ b/question28/js/password.js
@@ -43,9 +43,13 @@ passwordToggleButtons.forEach((passwordToggleButton) => {
 });
 
 const setNewPassword = () => {
-  const newPasswordValue = passwordInputArea.value;
-  const registeredUserData = localStorage.getItem('userData'); 
+  const registeredUserData = localStorage.getItem('userData');
+  if(!registeredUserData) {
+    window.location.href = "../notautherize.html";;
+    return;
+  }
   const registeredUserJsonData = JSON.parse(registeredUserData);
+  const newPasswordValue = passwordInputArea.value;
   registeredUserJsonData.password = newPasswordValue; 
   const newUserData = JSON.stringify(registeredUserJsonData);
   localStorage.setItem('userData', newUserData);
@@ -56,7 +60,7 @@ const init = () => {
   const token = chance.guid();
   localStorage.setItem('tokenForNewPassword', token);
   localStorage.removeItem('tokenForPasswordReset');
-  window.location.href = `./password-done.html?token=${token}`;
+  // window.location.href = `./password-done.html?token=${token}`;
 }
 
 submitButton.addEventListener('click',init);

--- a/question28/login.html
+++ b/question28/login.html
@@ -4,18 +4,20 @@
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta http-equiv="X-UA-Compatible" content="ie=edge" />
-        <link href="./css/style.css" rel="stylesheet" />
+        <link href="../css/style.css" rel="stylesheet" />
+        <link href="../css/common.css" rel="stylesheet" />
+        <link href="../css/form.css" rel="stylesheet" />
         <script type="module" src="./js/login.js"></script>
         <title>TerraceTechフロントエンドエンジニア養成所</title>
     </head>
     <body>
         <div class="login">
             <div id="js-wrapper" class="wrapper">
-                <h1>Login</h1>
+                <h1 class="form-title">Login</h1>
                 <form method="post" id="js-form" novalidate>
                     <div>
                         <ul>
-                            <li>
+                            <li class="form-list">
                                 <label for="name_mail">ユーザー名/メールアドレス</label>
                                 <input type="text" id="name_mail" name="name_mail" class="js-name_mail" required />
                                 <span class="error"></span>

--- a/question28/login.html
+++ b/question28/login.html
@@ -13,18 +13,18 @@
     <body>
         <div class="login">
             <div id="js-wrapper" class="wrapper">
-                <h1 class="form-title">Login</h1>
+                <h1 class="form_title">Login</h1>
                 <form method="post" id="js-form" novalidate>
                     <div>
                         <ul>
-                            <li class="form-list">
+                            <li class="form_list">
                                 <label for="name_mail">ユーザー名/メールアドレス</label>
                                 <input type="text" id="name_mail" name="name_mail" class="js-name_mail" required />
                                 <span class="error"></span>
                             </li>
-                            <li class="form-list">
+                            <li class="form_list">
                                 <label for="password">パスワード</label>
-                                <button type="button" class="password-toggle-button" id="js-toggle-password-button">表示</button>
+                                <button type="button" class="password_toggle_button" id="js-toggle-password-button">表示</button>
                                 <input type="password" autocomplete="current-password" id="current-password" name="password" class="js-password" required />
                                 <span class="error"></span>
                             </li>

--- a/question28/loginFailure.html
+++ b/question28/loginFailure.html
@@ -4,7 +4,9 @@
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+        <link href="../css/common.css" rel="stylesheet" />
         <link href="./css/style.css" rel="stylesheet" />
+        <link href="../css/form.css" rel="stylesheet" />
         <title>TerraceTechフロントエンドエンジニア養成所</title>
     </head>
     <script>
@@ -14,7 +16,7 @@
     </script>
     <body>
         <div id="js-wrapper" class="wrapper">
-            <h1>Login Failure</h1>
+            <h1 class="form_title">Login Failure</h1>
             <p>ログインに失敗しました。もう一度お試しください。
             </p>
         </div>

--- a/question28/notautherize.html
+++ b/question28/notautherize.html
@@ -4,7 +4,9 @@
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+        <link href="../css/common.css" rel="stylesheet" />
         <link href="./css/style.css" rel="stylesheet" />
+        <link href="../css/form.css" rel="stylesheet" />
         <title>TerraceTechフロントエンドエンジニア養成所</title>
         <script>
             setTimeout(() => {
@@ -14,7 +16,7 @@
     </head>
     <body>
         <div id="js-wrapper" class="wrapper">
-            <h1>NOT AUTHORIZED</h1>
+            <h1 class="form_title">NOT AUTHORIZED</h1>
         </div>
     </body>
 </html>

--- a/question28/register-done.html
+++ b/question28/register-done.html
@@ -5,6 +5,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta http-equiv="X-UA-Compatible" content="ie=edge" />
         <link href="./css/style.css" rel="stylesheet" />
+        <link href="../css/common.css" rel="stylesheet" />
         <title>TerraceTechフロントエンドエンジニア養成所</title>
     </head>
     <body>

--- a/question28/register-done.html
+++ b/question28/register-done.html
@@ -5,12 +5,13 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta http-equiv="X-UA-Compatible" content="ie=edge" />
         <link href="./css/style.css" rel="stylesheet" />
+        <link href="../css/form.css" rel="stylesheet" />
         <link href="../css/common.css" rel="stylesheet" />
         <title>TerraceTechフロントエンドエンジニア養成所</title>
     </head>
     <body>
         <div class="register-done done">
-            <div class="register-done_txt">
+            <div class="register-done_txt done_txt">
                 <p>会員登録が完了しました</p>
                 <p>登録が完了しましたので、ログインしてマイページに進んでください</p>
             </div>

--- a/question28/register.html
+++ b/question28/register.html
@@ -12,21 +12,21 @@
     </head>
     <body>
         <div id="js-wrapper" class="wrapper">
-            <h1 class="form-title">Sign Up</h1>
+            <h1 class="form_title">Sign Up</h1>
             <form method="post" id="js-form" novalidate>
                 <div>
                     <ul>
-                        <li class="form-list">
+                        <li class="form_list">
                             <label for="name">ユーザー名</label>
                             <input type="text" id="name" name="name" class="js-name" required data-maxlength="16"/>
                             <span class="error"></span>
                         </li>
-                        <li class="form-list">
+                        <li class="form_list">
                             <label for="mail">メールアドレス</label>
                             <input type="email" id="mail" name="email" class="js-email" required>
                             <span class="error"></span>
                         </li>
-                        <li class="form-list">
+                        <li class="form_list">
                             <label for="password">パスワード</label>
                             <input type="password" autocomplete="new-password" id="new-password" name="password" class="js-password" required>
                             <span class="error"></span>

--- a/question28/register.html
+++ b/question28/register.html
@@ -4,27 +4,29 @@
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta http-equiv="X-UA-Compatible" content="ie=edge" />
-        <link href="./css/style.css" rel="stylesheet" />
+        <link href="../css/style.css" rel="stylesheet" />
+        <link href="../css/common.css" rel="stylesheet" />
+        <link href="../css/form.css" rel="stylesheet" />
         <script type="module" src="./js/register.js"></script>
         <title>TerraceTechフロントエンドエンジニア養成所</title>
     </head>
     <body>
         <div id="js-wrapper" class="wrapper">
-            <h1>Sign Up</h1>
+            <h1 class="form-title">Sign Up</h1>
             <form method="post" id="js-form" novalidate>
                 <div>
                     <ul>
-                        <li>
+                        <li class="form-list">
                             <label for="name">ユーザー名</label>
                             <input type="text" id="name" name="name" class="js-name" required data-maxlength="16"/>
                             <span class="error"></span>
                         </li>
-                        <li>
+                        <li class="form-list">
                             <label for="mail">メールアドレス</label>
                             <input type="email" id="mail" name="email" class="js-email" required>
                             <span class="error"></span>
                         </li>
-                        <li>
+                        <li class="form-list">
                             <label for="password">パスワード</label>
                             <input type="password" autocomplete="new-password" id="new-password" name="password" class="js-password" required>
                             <span class="error"></span>
@@ -43,15 +45,15 @@
         <div role="dialog" aria-labelledby="dialogTitle" aria-describedby="dialogDesc" id="js-modal" class="modal hidden" >
             <button type="button" id="js-close" class="close_button">×</button>
             <div class="modal_container" id="js-modal-container">
-                <h2 id="dialogTitle">利用規約</h2>
+                <h2 id="dialogTitle" class="modal_title" >利用規約</h2>
                 <div id="dialogDesc" class="modal_content">
                     <p>
                         この利用規約（以下，「本規約」といいます。）は，＿＿＿＿＿（以下，「当社」といいます。）がこのウェブサイト上で提供するサービス（以下，「本サービス」といいます。）の利用条件を定めるものです。登録ユーザーの皆さま（以下，「ユーザー」といいます。）には，本規約に従って，本サービスをご利用いただきます。
                     </p>
                 </div>
                 <div class="modal_content">
-                    <h3>第1条（適用）</h3>
-                    <ol>
+                    <h3 class="modal_subtitle">第1条（適用）</h3>
+                    <ol class="modal_text">
                         <li>本規約は，ユーザーと当社との間の本サービスの利用に関わる一切の関係に適用されるものとします。</li>
                         <li>
                             当社は本サービスに関し，本規約のほか，ご利用にあたってのルール等，各種の定め（以下，「個別規定」といいます。）をすることがあります。これら個別規定はその名称のいかんに関わらず，本規約の一部を構成するものとします。
@@ -61,7 +63,7 @@
                 </div>
                 <div class="modal_content">
                     <h3>第2条（利用登録）</h3>
-                    <ol>
+                    <ol class="modal_text">
                         <li>本規約は，ユーザーと当社との間の本サービスの利用に関わる一切の関係に適用されるものとします。</li>
                         <li>
                             当社は本サービスに関し，本規約のほか，ご利用にあたってのルール等，各種の定め（以下，「個別規定」といいます。）をすることがあります。これら個別規定はその名称のいかんに関わらず，本規約の一部を構成するものとします。
@@ -71,7 +73,7 @@
                 </div>
                 <div class="modal_content">
                     <h3>第3条（ユーザーIDおよびパスワードの管理）</h3>
-                    <ol>
+                    <ol class="modal_text">
                         <li>ユーザーは，自己の責任において，本サービスのユーザーIDおよびパスワードを適切に管理するものとします。</li>
                         <li>
                             ユーザーは，いかなる場合にも，ユーザーIDおよびパスワードを第三者に譲渡または貸与し，もしくは第三者と共用することはできません。当社は，ユーザーIDとパスワードの組み合わせが登録情報と一致してログインされた場合には，そのユーザーIDを登録しているユーザー自身による利用とみなします。
@@ -81,7 +83,7 @@
                 </div>
                 <div class="modal_content">
                     <h3>第4条（利用料金および支払方法）</h3>
-                    <ol>
+                    <ol class="modal_text">
                         <li>ユーザーは，本サービスの有料部分の対価として，当社が別途定め，本ウェブサイトに表示する利用料金を，当社が指定する方法により支払うものとします。</li>
                         <li>ユーザーが利用料金の支払を遅滞した場合には，ユーザーは年14．6％の割合による遅延損害金を支払うものとします。</li>
                     </ol>
@@ -89,7 +91,7 @@
                 <div class="modal_content">
                     <h3>第5条（禁止事項）</h3>
                     <p>ユーザーは，本サービスの利用にあたり，以下の行為をしてはなりません。</p>
-                    <ol>
+                    <ol class="modal_text">
                         <li>法令または公序良俗に違反する行為</li>
                         <li>犯罪行為に関連する行為</li>
                         <li>本サービスの内容等，本サービスに含まれる著作権，商標権ほか知的財産権を侵害する行為</li>
@@ -124,7 +126,7 @@
                 </div>
                 <div class="modal_content">
                     <h3>第7条（利用制限および登録抹消）</h3>
-                    <ol>
+                    <ol class="modal_text">
                         <li>
                             当社は，ユーザーが以下のいずれかに該当する場合には，事前の通知なく，ユーザーに対して，本サービスの全部もしくは一部の利用を制限し，またはユーザーとしての登録を抹消することができるものとします。
                             <ol>
@@ -143,7 +145,7 @@
                     <h3>第8条（退会）</h3>
                     <p>ユーザーは，当社の定める退会手続により，本サービスから退会できるものとします。</p>
                     <h3>第9条（保証の否認および免責事項）</h3>
-                    <ol>
+                    <ol class="modal_text">
                         <li>
                             当社は，本サービスに事実上または法律上の瑕疵（安全性，信頼性，正確性，完全性，有効性，特定の目的への適合性，セキュリティなどに関する欠陥，エラーやバグ，権利侵害などを含みます。）がないことを明示的にも黙示的にも保証しておりません。
                         </li>

--- a/question28/register/password-done.html
+++ b/question28/register/password-done.html
@@ -4,18 +4,18 @@
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta http-equiv="X-UA-Compatible" content="ie=edge" />
-        <link href="./css/style.css" rel="stylesheet" />
+        <link href="../css/style.css" rel="stylesheet" />
+        <link href="../css/form.css" rel="stylesheet" />
         <link href="../css/common.css" rel="stylesheet" />
         <title>TerraceTechフロントエンドエンジニア養成所</title>
     </head>
     <body>
-        <div class="register-done done">
-            <div class="register-done_txt">
-                <p>会員登録が完了しました</p>
-                <p>登録が完了しましたので、ログインしてマイページに進んでください</p>
+        <div class="password-done done">
+            <div class="password-done_txt done_txt">
+                <p>パスワード再設定が完了しました</p>
             </div>
-            <div class="register-done_link done_link">
-                <a href="./login.html">ログイン画面へ</a>
+            <div class="password-done_link done_link">
+                <a href="../login.html">ログイン画面へ</a>
             </div>
         </div>
     </body>

--- a/question28/register/password-done.html
+++ b/question28/register/password-done.html
@@ -7,6 +7,7 @@
         <link href="../css/style.css" rel="stylesheet" />
         <link href="../css/form.css" rel="stylesheet" />
         <link href="../css/common.css" rel="stylesheet" />
+        <script type="module" src="../js/password-done.js"></script>
         <title>TerraceTechフロントエンドエンジニア養成所</title>
     </head>
     <body>

--- a/question28/register/password.html
+++ b/question28/register/password.html
@@ -25,7 +25,7 @@
                         <li class="form_list">
                             <label for="confirmPassword">確認のためのパスワード入力</label>
                             <button type="button" class="password_toggle_button" data-button="toggle-password-button">表示</button>
-                            <input type="password" autocomplete="new-password" id="confirm-password" name="password" required class="input" data-input="confirm-password"/>
+                            <input type="password" autocomplete="new-password" id="confirm-password" name="confirm_password" required class="input" data-input="confirm-password"/>
                             <span class="error"></span>
                         </li>
                     </ul>

--- a/question28/register/password.html
+++ b/question28/register/password.html
@@ -4,13 +4,15 @@
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta http-equiv="X-UA-Compatible" content="ie=edge" />
-        <script type="module" src="../js/password.js"></script>
         <link href="../css/style.css" rel="stylesheet" />
+        <link href="../css/common.css" rel="stylesheet" />
+        <link href="../css/form.css" rel="stylesheet" />
+        <script type="module" src="../js/password.js"></script>
         <title>TerraceTechフロントエンドエンジニア養成所</title>
     </head>
     <body>
         <div id="js-wrapper" class="wrapper">
-            <h1>Password Reset</h1>
+            <h1 class="form-title">Password Reset</h1>
             <form method="post" id="form" novalidate>
                 <div>
                     <ul>

--- a/question28/register/password.html
+++ b/question28/register/password.html
@@ -12,19 +12,19 @@
     </head>
     <body>
         <div id="js-wrapper" class="wrapper">
-            <h1 class="form-title">Password Reset</h1>
+            <h1 class="form_title">Password Reset</h1>
             <form method="post" id="form" novalidate>
                 <div>
                     <ul>
-                        <li class="form-list">
+                        <li class="form_list">
                             <label for="password">新規パスワード入力</label>
-                            <button type="button" class="password-toggle-button" data-button="toggle-password-button">表示</button>
+                            <button type="button" class="password_toggle_button" data-button="toggle-password-button">表示</button>
                             <input type="password" autocomplete="new-password" id="new-password" name="password" required class="input js-password"/>
                             <span class="error"></span>
                         </li>
-                        <li class="form-list">
+                        <li class="form_list">
                             <label for="confirmPassword">確認のためのパスワード入力</label>
-                            <button type="button" class="password-toggle-button" data-button="toggle-password-button">表示</button>
+                            <button type="button" class="password_toggle_button" data-button="toggle-password-button">表示</button>
                             <input type="password" autocomplete="new-password" id="confirm-password" name="password" required class="input js-confirm-password"/>
                             <span class="error"></span>
                         </li>

--- a/question28/register/password.html
+++ b/question28/register/password.html
@@ -19,13 +19,13 @@
                         <li class="form_list">
                             <label for="password">新規パスワード入力</label>
                             <button type="button" class="password_toggle_button" data-button="toggle-password-button">表示</button>
-                            <input type="password" autocomplete="new-password" id="new-password" name="password" required class="input js-password"/>
+                            <input type="password" autocomplete="new-password" id="new-password" name="password" required class="input" data-input="password"/>
                             <span class="error"></span>
                         </li>
                         <li class="form_list">
                             <label for="confirmPassword">確認のためのパスワード入力</label>
                             <button type="button" class="password_toggle_button" data-button="toggle-password-button">表示</button>
-                            <input type="password" autocomplete="new-password" id="confirm-password" name="password" required class="input js-confirm-password"/>
+                            <input type="password" autocomplete="new-password" id="confirm-password" name="password" required class="input" data-input="confirm-password"/>
                             <span class="error"></span>
                         </li>
                     </ul>


### PR DESCRIPTION
# [Task28]
パスワードを忘れた方へ画面作成
https://github.com/kenmori/handsonFrontend/blob/master/work/markup/1.md#28

## [codesandbox](https://codesandbox.io/s/github/csakyo/homework/tree/feature/task28-4/question28) 

## 課題28仕様
パスワード忘れた方へ(forgetpassword.html)のページを作ってください

## 今回実装点
①パスワード変更ページ(password.html/password.js)
inputの値が同じでバリデーションが通ればパスワードを再発行と新たなトークンを発行して ローカルストレージに埋め込みor以前のそれを破棄、変更してください。

②パスワード再設定完了ページ(password-done.html/password-done.js)
register/passworddone.html?token=tagaerega <-新しいトークン で飛ばします
完了ページでは urlパラメータからトークンと直近で作られたトークンがローカルストレージのそれと合っていたら
「パスワード再設定が完了しました」 「ログインページへ」を表示し
間違っていたりトークンがなかったり直叩きでurlが間違っていたら 権限なしページに飛ばしてください
その後、新たに作ったパスワードでログインができるようにします

【仕様外】
CSSファイルについて整理しました。
common.css → 全体での共通部分
form.css → formにて共通で使用している部分

## 確認してほしい点
### 【動作確認での前提条件】
会員登録画面(register.html)にて会員登録をして、ローカルストレージに会員情報が保存されている。
↓
パスワードをお忘れの方へページ(forgetpassword.html)へ遷移してもらい、登録したメールアドレスを入力しsubmit、パスワード再設定ページ(password.html)へ遷移される。


### 【動作確認箇所】
①パスワード変更ページ(password.html)
* inputの値が同じでバリデーションが通れば送信ボタンが押せて、パスワード変更完了ページへ遷移する

②パスワード変更完了ページ(password-done.html)
* localstrageに保存されたパスワード変更のためのtoken(tokenForNewPassword)の値と、遷移先URLパラメータのtoken値が合っている
・URLのパラメータ値を故意に変更した場合、notautherize.htmlページに飛ぶ

↓
その後、ログインページへ遷移し、新しいPWでログインができる

### 前回の課題から変更したファイル
* js/password.js
* js/login.js
* password.html
* login.html
* css/style.css

### 前回の課題から追加したファイル
* password-done.html
* password-done.js
* /css/common.css
* /css/form.css

## 前回までの実装
この課題から会員登録された内容はlocalstorage内に保有され ログイン時は固定値ではなく localstorage内の値とチェックされます。 イメージしたいのはローカルストレージはここではサーバー内のテーブルとして使っています。 なので現実的ではそのような実装はないですが、ここの課題はそれで実装したいです 
会員登録画面でsubmitした時、localStorage内の値とチェックしてメールアドレスが既に登録されていた場合はエラーを出します。
上記で作ったメールアドレス兼ユーザー名を入力するところがあります
メールアドレスのinput値がバリデーションを通れば送信ボタンが押せます
もしメールアドレスが登録がされていない場合は「見つかりませんでした」というエラーメッセージを出してください
この課題の実装では forgetpassword.htmlでsubmitしたらトークンを発行して(仮にこの説明では482r22fafahとします)、ローカルストレージに保存。 そのあと register/password.htmlへ飛ばしてください
その際のリンクはregister/password.html?token=482r22fafah みたいなurlにして(このリンクが本来メール本文にあるリンクのイメージです)
「新規パスワード入力」 「確認のためのパスワード入力」 があり、バリデーションも効きます。
フロントはurlパラメータのtokenがすぐ前で発行した482r22fafahかどうかを確認します。 (ローカルストレージがサーバー側の役割をしているイメージ)
もしtokenが間違っていたら notautherize.html 権限がありませんページに飛ばしてください
urlパラメータが正しい場合にregister/password.htmlを表示します

【仕様外】
パスワードの表示・非表示の機能を実装しました。


## [Comment for this Task]
Please see below for the changes and additions that have been made.