### PR TITLE
【Task28】Create Forgot Password page⑤

### DIFF
--- a/question28/js/login.js
+++ b/question28/js/login.js
@@ -36,7 +36,10 @@ passwordInputArea.addEventListener('blur', (e) => {
 
 passwordToggleButton.addEventListener('click', togglePassword); 
 passwordToggleButton.addEventListener('click', resetValidation);
-passwordToggleButton.addEventListener('blur', validationForTargetForm);
+passwordToggleButton.addEventListener('blur', (e) => {
+  validationForTargetForm(e);
+  toggleDisabledOfSubmitButton(checkAllValidity());
+});
 
 
 const checkData = ({ name_mail, password }) => {

--- a/question28/js/login.js
+++ b/question28/js/login.js
@@ -1,4 +1,4 @@
-import { validateInputValue } from "./modules/validations";
+import { validateInputValue, resetValidation, validationForTargetForm } from "./modules/validations";
 import { togglePassword } from "./modules/togglePassword";
 import { Chance } from "chance";
 const chance = new Chance();
@@ -33,6 +33,10 @@ passwordInputArea.addEventListener('blur', (e) => {
 });
 
 passwordToggleButton.addEventListener('click', togglePassword); 
+
+passwordToggleButton.addEventListener('click', resetValidation);
+passwordToggleButton.addEventListener('blur', validationForTargetForm);
+
 
 const checkData = ({ name_mail, password }) => {
   const registeredUserData = JSON.parse(localStorage.getItem('userData'));

--- a/question28/js/login.js
+++ b/question28/js/login.js
@@ -28,12 +28,13 @@ userInfoInputArea.addEventListener('blur', (e) => {
  });
 
 passwordInputArea.addEventListener('blur', (e) => {
-   validateInputValue(e);
+  if (e.relatedTarget !== passwordToggleButton) {
+    validateInputValue(e);
+  }
    toggleDisabledOfSubmitButton(checkAllValidity());
 });
 
 passwordToggleButton.addEventListener('click', togglePassword); 
-
 passwordToggleButton.addEventListener('click', resetValidation);
 passwordToggleButton.addEventListener('blur', validationForTargetForm);
 

--- a/question28/js/modules/validations.js
+++ b/question28/js/modules/validations.js
@@ -67,7 +67,5 @@ export const resetValidation = (e) => {
   const errorMessage = e.target.parentNode.querySelector('[data-error="error"]');
   const inputOfPassword = e.target.parentNode.querySelector('[data-input="password"]');
   errorMessage.textContent = ""; 
-  inputOfPassword.classList.remove("invalid");
-  inputOfPassword.classList.remove("valid");
-  inputOfPassword.classList.remove("invalid_mismatch");
+  inputOfPassword.classList.remove("invalid", "valid", "invalid_mismatch");
 }

--- a/question28/js/modules/validations.js
+++ b/question28/js/modules/validations.js
@@ -51,3 +51,23 @@ export const validateInputValue = (e) => {
   const result = validationInfo[targetForm.name].validation(value);
   setValidationEvents(result,targetForm);
 } 
+
+export const validateInputValueForButton = (targetForm) => {
+  const value = targetForm.value.trim();
+  const result = validationInfo[targetForm.name].validation(value);
+  setValidationEvents(result,targetForm);
+} 
+
+export const validationForTargetForm = (e) => {
+  if (e.relatedTarget === e.target.parentNode.querySelector('input')) return;
+  validateInputValueForButton(e.target.parentNode.querySelector('[data-input="password"]')); 
+}
+
+export const resetValidation = (e) => {
+  const errorMessage = e.target.parentNode.querySelector('[data-error="error"]');
+  const inputOfPassword = e.target.parentNode.querySelector('[data-input="password"]');
+  errorMessage.textContent = ""; 
+  inputOfPassword.classList.remove("invalid");
+  inputOfPassword.classList.remove("valid");
+  inputOfPassword.classList.remove("invalid_mismatch");
+}

--- a/question28/js/password.js
+++ b/question28/js/password.js
@@ -31,7 +31,9 @@ for (const elem of toggleButtonsForPassword) {
 
 for (const input of [passwordInputArea, confirmPasswordInputArea]) {
   input.addEventListener("blur", (e) => {
+    if (e.relatedTarget !== input.parentNode.querySelector('[data-button="toggle-password-button"]')) {
       validateInputValue(e);
+    }
     
     if (confirmPasswordInputArea.value && !(passwordInputArea.value === confirmPasswordInputArea.value)) {
         confirmPasswordInputArea.nextElementSibling.textContent = "入力された値が一致してません";

--- a/question28/js/password.js
+++ b/question28/js/password.js
@@ -1,12 +1,16 @@
 import { validateInputValue } from "./modules/validations";
+import { validationForTargetForm } from "./modules/validations";
+import { resetValidation } from "./modules/validations";
 import { togglePassword } from "./modules/togglePassword";
 import { Chance } from "chance";
 const chance = new Chance();
 
 const submitButton = document.getElementById('js-submit-button');
-const passwordInputArea = document.querySelector('[data-input="password"]');
-const confirmPasswordInputArea = document.querySelector('[data-input="confirm-password"]');
+const passwordInputArea = document.querySelector('[data-input-password="password"]');
+const confirmPasswordInputArea = document.querySelector('[data-input-password="confirm-password"]');
 const passwordToggleButtons = document.querySelectorAll('[data-button]');
+const toggleButtonsForPassword = document.querySelectorAll('[data-button="toggle-password-button"]');
+
 
 const url = new URL(window.location.href);
 const params = url.searchParams;
@@ -22,9 +26,14 @@ const toggleDisabledOfSubmitButton = (isValid) => {
   submitButton.disabled = !isValid;
 }
 
+for (const elem of toggleButtonsForPassword) {
+  elem.addEventListener('click', resetValidation);
+  elem.addEventListener('blur', validationForTargetForm);
+}
+
 for (const input of [passwordInputArea, confirmPasswordInputArea]) {
   input.addEventListener("blur", (e) => {
-    validateInputValue(e);
+      validateInputValue(e);
     
     if (confirmPasswordInputArea.value && !(passwordInputArea.value === confirmPasswordInputArea.value)) {
         confirmPasswordInputArea.nextElementSibling.textContent = "入力された値が一致してません";

--- a/question28/js/password.js
+++ b/question28/js/password.js
@@ -26,7 +26,10 @@ const toggleDisabledOfSubmitButton = (isValid) => {
 
 for (const elem of toggleButtonsForPassword) {
   elem.addEventListener('click', resetValidation);
-  elem.addEventListener('blur', validationForTargetForm);
+  elem.addEventListener('blur', (e) => {
+    validationForTargetForm(e);
+    toggleDisabledOfSubmitButton(isValidAllInputsValue()); 
+  });
 }
 
 for (const input of [passwordInputArea, confirmPasswordInputArea]) {

--- a/question28/js/password.js
+++ b/question28/js/password.js
@@ -1,6 +1,4 @@
-import { validateInputValue } from "./modules/validations";
-import { validationForTargetForm } from "./modules/validations";
-import { resetValidation } from "./modules/validations";
+import { validateInputValue, validationForTargetForm, resetValidation } from "./modules/validations";
 import { togglePassword } from "./modules/togglePassword";
 import { Chance } from "chance";
 const chance = new Chance();

--- a/question28/js/register.js
+++ b/question28/js/register.js
@@ -1,4 +1,5 @@
-import { validateInputValue } from "./modules/validations";
+import { validateInputValue, resetValidation, validationForTargetForm } from "./modules/validations";
+import { togglePassword } from "./modules/togglePassword";
 
 export const submitButton = document.getElementById('js-submit-button');
 const textLinkToTerms = document.getElementById('js-terms-textlink');
@@ -11,7 +12,7 @@ const modalContainer = document.getElementById("js-modal-container");
 const nameInputArea = document.querySelector(".js-name");
 const mailInputArea = document.querySelector(".js-email");
 const passwordInputArea = document.querySelector(".js-password");
-
+const passwordToggleButton = document.getElementById('js-toggle-password-button');
 
 textLinkToTerms.addEventListener('click',()=>{
     modal.classList.remove('hidden');
@@ -61,6 +62,10 @@ for (const input of [nameInputArea, mailInputArea, passwordInputArea]) {
 checkbox.addEventListener("change", () => {
   toggleDisabledOfSubmitButton(isValidAllInputsValue() && checkbox.checked);
 });
+
+passwordToggleButton.addEventListener('click', togglePassword); 
+passwordToggleButton.addEventListener('click', resetValidation);
+passwordToggleButton.addEventListener('blur', validationForTargetForm);
 
 submitButton.addEventListener('click',() => {
   const registeredUserData = JSON.parse(localStorage.getItem('userData'));

--- a/question28/js/register.js
+++ b/question28/js/register.js
@@ -52,12 +52,19 @@ const toggleDisabledOfSubmitButton = (isValid) => {
   submitButton.disabled = !isValid;
 }
 
-for (const input of [nameInputArea, mailInputArea, passwordInputArea]) {
+for (const input of [nameInputArea, mailInputArea]) {
   input.addEventListener("blur", (e) => {
     validateInputValue(e);
     toggleDisabledOfSubmitButton(isValidAllInputsValue() && checkbox.checked);
   });
 }
+
+passwordInputArea.addEventListener("blur", (e) => {
+  if (e.relatedTarget !== passwordToggleButton) {
+    validateInputValue(e);
+  }
+  toggleDisabledOfSubmitButton(isValidAllInputsValue() && checkbox.checked); 
+})
 
 checkbox.addEventListener("change", () => {
   toggleDisabledOfSubmitButton(isValidAllInputsValue() && checkbox.checked);

--- a/question28/js/register.js
+++ b/question28/js/register.js
@@ -72,7 +72,10 @@ checkbox.addEventListener("change", () => {
 
 passwordToggleButton.addEventListener('click', togglePassword); 
 passwordToggleButton.addEventListener('click', resetValidation);
-passwordToggleButton.addEventListener('blur', validationForTargetForm);
+passwordToggleButton.addEventListener('blur', (e) => {
+  validationForTargetForm(e);
+  toggleDisabledOfSubmitButton(isValidAllInputsValue() && checkbox.checked); 
+});
 
 submitButton.addEventListener('click',() => {
   const registeredUserData = JSON.parse(localStorage.getItem('userData'));

--- a/question28/login.html
+++ b/question28/login.html
@@ -20,13 +20,13 @@
                             <li class="form_list">
                                 <label for="name_mail">ユーザー名/メールアドレス</label>
                                 <input type="text" id="name_mail" name="name_mail" class="js-name_mail" required />
-                                <span class="error"></span>
+                                <span class="error" data-error="error"></span>
                             </li>
                             <li class="form_list">
                                 <label for="password">パスワード</label>
-                                <button type="button" class="password_toggle_button" id="js-toggle-password-button">表示</button>
-                                <input type="password" autocomplete="current-password" id="current-password" name="password" class="js-password" required />
-                                <span class="error"></span>
+                                <button type="button" class="password_toggle_button" id="js-toggle-password-button" data-button="toggle-password-button">表示</button>
+                                <input type="password" autocomplete="current-password" id="current-password" name="password" class="js-password" data-input="password" required />
+                                <span class="error" data-error="error"></span>
                             </li>
                         </ul>
                     </div>

--- a/question28/register.html
+++ b/question28/register.html
@@ -19,17 +19,18 @@
                         <li class="form_list">
                             <label for="name">ユーザー名</label>
                             <input type="text" id="name" name="name" class="js-name" required data-maxlength="16"/>
-                            <span class="error"></span>
+                            <span class="error" data-error="error"></span>
                         </li>
                         <li class="form_list">
                             <label for="mail">メールアドレス</label>
                             <input type="email" id="mail" name="email" class="js-email" required>
-                            <span class="error"></span>
+                            <span class="error" data-error="error"></span>
                         </li>
                         <li class="form_list">
                             <label for="password">パスワード</label>
-                            <input type="password" autocomplete="new-password" id="new-password" name="password" class="js-password" required>
-                            <span class="error"></span>
+                            <button type="button" class="password_toggle_button" id="js-toggle-password-button" data-button="toggle-password-button">表示</button>
+                            <input type="password" autocomplete="new-password" id="new-password" name="password" class="js-password" data-input="password" required>
+                            <span class="error" data-error="error"></span>
                         </li>
                     </ul>
                 </div>

--- a/question28/register/password.html
+++ b/question28/register/password.html
@@ -18,15 +18,15 @@
                     <ul>
                         <li class="form_list">
                             <label for="password">新規パスワード入力</label>
-                            <button type="button" class="password_toggle_button" data-button="toggle-password-button">表示</button>
-                            <input type="password" autocomplete="new-password" id="new-password" name="password" required class="input" data-input="password"/>
-                            <span class="error"></span>
+                            <button type="button" id="togglebtn" class="password_toggle_button" data-button="toggle-password-button">表示</button>
+                            <input type="password" autocomplete="new-password" id="new-password" name="password" required class="input" data-input="password" data-input-password="password" />
+                            <span class="error" data-error="error"></span>
                         </li>
                         <li class="form_list">
                             <label for="confirmPassword">確認のためのパスワード入力</label>
-                            <button type="button" class="password_toggle_button" data-button="toggle-password-button">表示</button>
-                            <input type="password" autocomplete="new-password" id="confirm-password" name="confirm_password" required class="input" data-input="confirm-password"/>
-                            <span class="error"></span>
+                            <button type="button" id="togglebtn0" class="password_toggle_button" data-button="toggle-password-button">表示</button>
+                            <input type="password" autocomplete="new-password" id="confirm-password" name="confirm_password" required class="input" data-input="password" data-input-password="confirm-password" />
+                            <span class="error" data-error="error"></span>
                         </li>
                     </ul>
                 </div>


### PR DESCRIPTION
# [Task28]
パスワードを忘れた方へ画面作成
https://github.com/kenmori/handsonFrontend/blob/master/work/markup/1.md#28

## [codesandbox](https://codesandbox.io/s/github/csakyo/homework/tree/feature/task28-5/question28) 

## 今回実装点（課題28の仕様は満たしています）
[前回いただいたコメント](https://github.com/csakyo/homework/pull/45#issuecomment-1452882914)
上記のコメントについて修正しています。

### 概要
パスワード入力欄で使用している、パスワード表示非表示ボタンを押す際にバリデーションが走ってしまう点について修正しました。

### 【動作確認箇所】
パスワード表示非表示ボタンを押下時はバリデーションがリセットされるよう実装しました。

①パスワード表示非表示ボタンを押す際にバリデーションが走らない。
②パスワード表示非表示ボタンを押した後に入力しようとしても（blur先がinputの場合）バリデーションが走らない。
③パスワード表示非表示ボタンを押した後にblurした場合（input以外を）、バリデーションが走る。
※その他、動きが変なところや、使いづらい点などがありましたらご教示いただけると幸いです。

### 該当ページ
* パスワード変更ページ（password.html）
* ログインページ（login.html）
* 会員登録画面ページ（register.html）


### 前回の課題から変更したファイル
* js/password.js
* js/login.js
* js/register.js
* password.html
* login.html
* register.html
* validations.js

## 前回までの実装（課題28の仕様については満たしています）
この課題から会員登録された内容はlocalstorage内に保有され ログイン時は固定値ではなく localstorage内の値とチェックされます。 イメージしたいのはローカルストレージはここではサーバー内のテーブルとして使っています。 なので現実的ではそのような実装はないですが、ここの課題はそれで実装したいです 
会員登録画面でsubmitした時、localStorage内の値とチェックしてメールアドレスが既に登録されていた場合はエラーを出します。
上記で作ったメールアドレス兼ユーザー名を入力するところがあります
メールアドレスのinput値がバリデーションを通れば送信ボタンが押せます
もしメールアドレスが登録がされていない場合は「見つかりませんでした」というエラーメッセージを出してください
この課題の実装では forgetpassword.htmlでsubmitしたらトークンを発行して(仮にこの説明では482r22fafahとします)、ローカルストレージに保存。 そのあと register/password.htmlへ飛ばしてください
その際のリンクはregister/password.html?token=482r22fafah みたいなurlにして(このリンクが本来メール本文にあるリンクのイメージです)
「新規パスワード入力」 「確認のためのパスワード入力」 があり、バリデーションも効きます。
フロントはurlパラメータのtokenがすぐ前で発行した482r22fafahかどうかを確認します。 (ローカルストレージがサーバー側の役割をしているイメージ)
もしtokenが間違っていたら notautherize.html 権限がありませんページに飛ばしてください
urlパラメータが正しい場合にregister/password.htmlを表示します
inputの値が同じでバリデーションが通ればパスワードを再発行と新たなトークンを発行して ローカルストレージに埋め込みor以前のそれを破棄、変更してください。
register/passworddone.html?token=tagaerega <-新しいトークン で飛ばします
完了ページでは urlパラメータからトークンと直近で作られたトークンがローカルストレージのそれと合っていたら
「パスワード再設定が完了しました」 「ログインページへ」を表示し
間違っていたりトークンがなかったり直叩きでurlが間違っていたら 権限なしページに飛ばしてください
その後、新たに作ったパスワードでログインができるようにします

【仕様外】
パスワードの表示・非表示の機能を実装しました。
CSSファイルについて整理しました。
common.css → 全体での共通部分
form.css → formにて共通で使用している部分


## [Comment for this Task]
Please see below for the changes and additions that have been made.